### PR TITLE
Fix for Laravel 4.2

### DIFF
--- a/src/Nitmedia/Wkhtml2pdf/Wkhtml2pdf.php
+++ b/src/Nitmedia/Wkhtml2pdf/Wkhtml2pdf.php
@@ -1,7 +1,7 @@
 <?php namespace Nitmedia\Wkhtml2pdf;
 
 use \Exception;
-use Illuminate\View\Environment;
+use Illuminate\View\Factory;
 use Illuminate\Config\Repository;
 
 /**
@@ -134,7 +134,7 @@ class Wkhtml2pdf
      * @param array $config
      * @return bool FALSE on failure
      */
-    public function __construct(Environment $view, Repository $config)
+    public function __construct(Factory $view, Repository $config)
     {
         $this->view = $view;
         $this->config = $config;


### PR DESCRIPTION
View / Pagination Environment Renamed

If you are directly referencing the Illuminate\View\Environment class or Illuminate\Pagination\Environment class, update your code to reference Illuminate\View\Factory and Illuminate\Pagination\Factory instead. These two classes have been renamed to better reflect their function.
