### PR TITLE
Change dd for dump

### DIFF
--- a/src/Nitmedia/Wkhtml2pdf/Wkhtml2pdf.php
+++ b/src/Nitmedia/Wkhtml2pdf/Wkhtml2pdf.php
@@ -874,7 +874,7 @@ class Wkhtml2pdf
 
         if($this->config->get('debug'))
         {
-            dd(array(
+            dump(array(
                 'input' => $input,
                 'command' => $command,
                 'content' => $content


### PR DESCRIPTION
As stated in laravel doc [dd](https://laravel.com/docs/5.2/helpers#method-dd) will stop the execution of the script and `dump` should be used instead