### PR TITLE
Fixed error output check

### DIFF
--- a/src/Nitmedia/Wkhtml2pdf/Wkhtml2pdf.php
+++ b/src/Nitmedia/Wkhtml2pdf/Wkhtml2pdf.php
@@ -881,8 +881,8 @@ class Wkhtml2pdf
             ));
         }
 
-        if (strpos(strtolower($content['stderr']), 'error'))
-            throw new Exception("System error <pre>" . $content['stderr'] . "</pre>");
+        if(preg_match('/error(?! ignored)/i', $content['stderr']))
+		throw new Exception("System error <pre>" . $content['stderr'] . "</pre>");
 
         if (strlen($content['stdout']) === 0)
             throw new Exception("WKHTMLTOPDF didn't return any data");


### PR DESCRIPTION
An exception is now thrown when the stderr contains the string "error" but only when it is not followed by " ignored" because this indicates that it is not a breaking error.

The regex "/error(?! ignored)/i" could or maybe should be updated in the future if a new wkhtmltopdf binary with new error messages is used.